### PR TITLE
fix(http): make ResponseBuilder::header merge existing headers

### DIFF
--- a/src/http/types.mbt
+++ b/src/http/types.mbt
@@ -132,8 +132,8 @@ pub fn ResponseBuilder::header(
   key : String,
   value : String,
 ) -> ResponseBuilder {
-  // 新しいマップを作成して値を設定
-  let new_headers = @hashmap.from_array([(key, value)])
+  let new_headers = self.headers.copy()
+  new_headers.set(key, value)
   { status: self.status, reason: self.reason, headers: new_headers }
 }
 


### PR DESCRIPTION
## Summary
- Fix `ResponseBuilder::header` to merge existing headers instead of discarding them
- Previously, calling `header()` created a new HashMap with only the specified key-value, losing all previous headers
- Now it copies existing headers and inserts/overrides the new key-value pair

## Fixes
#1

## Test plan
- [x] Build passes: `moon test`
- [ ] Manual verification: method chaining preserves headers
- [ ] Same key is overridden with latest value