### PR TITLE
fix(hda): make HdaResponseBuilder::header merge existing headers

### DIFF
--- a/src/hda/hda.mbt
+++ b/src/hda/hda.mbt
@@ -119,7 +119,8 @@ pub fn HdaResponseBuilder::header(
   key : String,
   value : String,
 ) -> HdaResponseBuilder {
-  let new_headers = @hashmap.from_array([(key, value)])
+  let new_headers = self.headers.copy()
+  new_headers.set(key, value)
   {
     status: self.status,
     reason: self.reason,


### PR DESCRIPTION
## Summary
- Fix `HdaResponseBuilder::header` to merge existing headers instead of discarding them
- Previously, calling `header()` created a new HashMap with only the specified key-value, losing all previous HX-* headers
- Now it copies existing headers and inserts/overrides the new key-value pair

## Fixes
#2

## Test plan
- [x] Build passes: `moon test`
- [ ] Manual verification: swap/target/trigger chaining preserves all headers
- [ ] Same key is overridden with latest value

## Notes
This follows the same fix pattern as #1 (ResponseBuilder::header).