### PR TITLE
fix(http): pass Response.headers to async_http.send_response

### DIFF
--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -50,7 +50,8 @@ async fn send_response(
   resp : Response,
 ) -> Unit {
   // ヘッダーを送信
-  conn.send_response(resp.status, resp.reason, extra_headers={})
+  let headers_map = Map::from_array(resp.headers.to_array())
+  conn.send_response(resp.status, resp.reason, extra_headers=headers_map)
 
   // ボディを送信
   match resp.body {


### PR DESCRIPTION
## Summary
- Fix `send_response` to pass Response.headers to async_http.send_response
- Previously, send_response passed an empty HashMap `{}` for extra_headers, ignoring all headers
- Content-Type and HX-* headers were never sent to the client
- Now converts Response.headers (@hashmap.HashMap) to Map (builtin type)

## Fixes
#3

## Test plan
- [x] Build passes: `moon test`
- [ ] Manual verification: Content-Type and HX-* headers are sent to client

## Notes
This completes the header handling fix chain:
- #1: ResponseBuilder::header merge behavior
- #2: HdaResponseBuilder::header merge behavior
- #3: Server::send_response passes headers to async_http