### PR TITLE
feat(html/hda): add bridge API between HdaAttrs and html.Attrs

### DIFF
--- a/src/hda/hda.mbt
+++ b/src/hda/hda.mbt
@@ -258,51 +258,51 @@ pub fn HdaAttrs::new() -> HdaAttrs {
 }
 
 ///|
-pub fn HdaAttrs::get(self : HdaAttrs, url : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-get", url)])
+// 内部ヘルパー: 属性を追加して新しい HdaAttrs を返す
+fn HdaAttrs::_add(self : HdaAttrs, key : String, value : String) -> HdaAttrs {
+  let new_attrs = self.attrs.copy()
+  new_attrs.set(key, value)
   { attrs: new_attrs }
+}
+
+///|
+pub fn HdaAttrs::get(self : HdaAttrs, url : String) -> HdaAttrs {
+  self._add("hx-get", url)
 }
 
 ///|
 pub fn HdaAttrs::post(self : HdaAttrs, url : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-post", url)])
-  { attrs: new_attrs }
+  self._add("hx-post", url)
 }
 
 ///|
 pub fn HdaAttrs::put(self : HdaAttrs, url : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-put", url)])
-  { attrs: new_attrs }
+  self._add("hx-put", url)
 }
 
 ///|
 pub fn HdaAttrs::delete(self : HdaAttrs, url : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-delete", url)])
-  { attrs: new_attrs }
+  self._add("hx-delete", url)
 }
 
 ///|
 pub fn HdaAttrs::patch(self : HdaAttrs, url : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-patch", url)])
-  { attrs: new_attrs }
+  self._add("hx-patch", url)
 }
 
 ///|
 pub fn HdaAttrs::swap(self : HdaAttrs, s : Swap) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-swap", s.to_string())])
-  { attrs: new_attrs }
+  self._add("hx-swap", s.to_string())
 }
 
 ///|
 pub fn HdaAttrs::target(self : HdaAttrs, selector : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-target", selector)])
-  { attrs: new_attrs }
+  self._add("hx-target", selector)
 }
 
 ///|
 pub fn HdaAttrs::trigger(self : HdaAttrs, t : Trigger) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-trigger", t.to_string())])
-  { attrs: new_attrs }
+  self._add("hx-trigger", t.to_string())
 }
 
 ///|
@@ -312,42 +312,47 @@ pub fn HdaAttrs::on(self : HdaAttrs, event : String) -> HdaAttrs {
 
 ///|
 pub fn HdaAttrs::push_url(self : HdaAttrs, url : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-push-url", url)])
-  { attrs: new_attrs }
+  self._add("hx-push-url", url)
 }
 
 ///|
 pub fn HdaAttrs::confirm(self : HdaAttrs, message : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-confirm", message)])
-  { attrs: new_attrs }
+  self._add("hx-confirm", message)
 }
 
 ///|
 pub fn HdaAttrs::disable(self : HdaAttrs) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-disable", "true")])
-  { attrs: new_attrs }
+  self._add("hx-disable", "true")
 }
 
 ///|
 pub fn HdaAttrs::encoding(self : HdaAttrs, encoding : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-encoding", encoding)])
-  { attrs: new_attrs }
+  self._add("hx-encoding", encoding)
 }
 
 ///|
 pub fn HdaAttrs::headers(self : HdaAttrs, headers : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-headers", headers)])
-  { attrs: new_attrs }
+  self._add("hx-headers", headers)
 }
 
 ///|
 pub fn HdaAttrs::params(self : HdaAttrs, params : String) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-vals", params)])
-  { attrs: new_attrs }
+  self._add("hx-vals", params)
 }
 
 ///|
 pub fn HdaAttrs::boost(self : HdaAttrs) -> HdaAttrs {
-  let new_attrs = @hashmap.from_array([("hx-boost", "true")])
-  { attrs: new_attrs }
+  self._add("hx-boost", "true")
+}
+
+///|
+/// HdaAttrs を html.Attrs に変換
+pub fn HdaAttrs::to_html_attrs(self : HdaAttrs) -> @html.Attrs {
+  let entries = self.attrs.to_array()
+  let mut html_attrs = @html.Attrs::new()
+  for i = 0; i < entries.length(); i = i + 1 {
+    let (key, value) = entries[i]
+    html_attrs = html_attrs.add(key, @html.AttrValue::Str(value))
+  }
+  html_attrs
 }

--- a/src/html/html.mbt
+++ b/src/html/html.mbt
@@ -35,6 +35,30 @@ pub fn Attrs::add(self : Attrs, key : String, value : AttrValue) -> Attrs {
 }
 
 ///|
+/// 2つの Attrs をマージする（prefer の属性が優先）
+pub fn Attrs::merge(prefer : Attrs, fallback : Attrs) -> Attrs {
+  // prefer のキーを追跡
+  let prefer_keys = @hashmap.new()
+  for i = 0; i < prefer.attrs.length(); i = i + 1 {
+    let (key, _) = prefer.attrs[i]
+    prefer_keys.set(key, "marker")
+  }
+
+  // fallback の重複しない属性を収集
+  let mut unique_fallback = []
+  for i = 0; i < fallback.attrs.length(); i = i + 1 {
+    let (key, value) = fallback.attrs[i]
+    match prefer_keys.get(key) {
+      Some(_) => () // prefer に存在する場合はスキップ
+      None => unique_fallback = unique_fallback + [(key, value)]
+    }
+  }
+
+  // prefer + unique_fallback（順序を維持）
+  { attrs: prefer.attrs + unique_fallback }
+}
+
+///|
 pub fn Attrs::class(self : Attrs, name : String) -> Attrs {
   self.add("class", Str(name))
 }
@@ -57,6 +81,54 @@ pub fn Attrs::attr_type(self : Attrs, t : String) -> Attrs {
 ///|
 pub fn Attrs::name(self : Attrs, n : String) -> Attrs {
   self.add("name", Str(n))
+}
+
+///|
+/// Htmx属性: hx-get
+pub fn Attrs::hx_get(self : Attrs, url : String) -> Attrs {
+  self.add("hx-get", Str(url))
+}
+
+///|
+/// Htmx属性: hx-post
+pub fn Attrs::hx_post(self : Attrs, url : String) -> Attrs {
+  self.add("hx-post", Str(url))
+}
+
+///|
+/// Htmx属性: hx-put
+pub fn Attrs::hx_put(self : Attrs, url : String) -> Attrs {
+  self.add("hx-put", Str(url))
+}
+
+///|
+/// Htmx属性: hx-delete
+pub fn Attrs::hx_delete(self : Attrs, url : String) -> Attrs {
+  self.add("hx-delete", Str(url))
+}
+
+///|
+/// Htmx属性: hx-patch
+pub fn Attrs::hx_patch(self : Attrs, url : String) -> Attrs {
+  self.add("hx-patch", Str(url))
+}
+
+///|
+/// Htmx属性: hx-swap
+pub fn Attrs::hx_swap(self : Attrs, swap : String) -> Attrs {
+  self.add("hx-swap", Str(swap))
+}
+
+///|
+/// Htmx属性: hx-target
+pub fn Attrs::hx_target(self : Attrs, selector : String) -> Attrs {
+  self.add("hx-target", Str(selector))
+}
+
+///|
+/// Htmx属性: hx-trigger
+pub fn Attrs::hx_trigger(self : Attrs, event : String) -> Attrs {
+  self.add("hx-trigger", Str(event))
 }
 
 ///|
@@ -298,6 +370,78 @@ pub fn ElementBuilder::name(
   n : String,
 ) -> ElementBuilder {
   { ..self, attrs: self.attrs.name(n) }
+}
+
+///|
+/// Htmx属性: hx-get
+pub fn ElementBuilder::hx_get(
+  self : ElementBuilder,
+  url : String,
+) -> ElementBuilder {
+  { ..self, attrs: self.attrs.hx_get(url) }
+}
+
+///|
+/// Htmx属性: hx-post
+pub fn ElementBuilder::hx_post(
+  self : ElementBuilder,
+  url : String,
+) -> ElementBuilder {
+  { ..self, attrs: self.attrs.hx_post(url) }
+}
+
+///|
+/// Htmx属性: hx-put
+pub fn ElementBuilder::hx_put(
+  self : ElementBuilder,
+  url : String,
+) -> ElementBuilder {
+  { ..self, attrs: self.attrs.hx_put(url) }
+}
+
+///|
+/// Htmx属性: hx-delete
+pub fn ElementBuilder::hx_delete(
+  self : ElementBuilder,
+  url : String,
+) -> ElementBuilder {
+  { ..self, attrs: self.attrs.hx_delete(url) }
+}
+
+///|
+/// Htmx属性: hx-patch
+pub fn ElementBuilder::hx_patch(
+  self : ElementBuilder,
+  url : String,
+) -> ElementBuilder {
+  { ..self, attrs: self.attrs.hx_patch(url) }
+}
+
+///|
+/// Htmx属性: hx-swap
+pub fn ElementBuilder::hx_swap(
+  self : ElementBuilder,
+  swap : String,
+) -> ElementBuilder {
+  { ..self, attrs: self.attrs.hx_swap(swap) }
+}
+
+///|
+/// Htmx属性: hx-target
+pub fn ElementBuilder::hx_target(
+  self : ElementBuilder,
+  selector : String,
+) -> ElementBuilder {
+  { ..self, attrs: self.attrs.hx_target(selector) }
+}
+
+///|
+/// Htmx属性: hx-trigger
+pub fn ElementBuilder::hx_trigger(
+  self : ElementBuilder,
+  event : String,
+) -> ElementBuilder {
+  { ..self, attrs: self.attrs.hx_trigger(event) }
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Add type-safe integration between HDA (htmx) attributes and HTML DSL
- Fix HdaAttrs accumulation bug (same issue as #1, #2)
- Add `HdaAttrs::to_html_attrs()` conversion function
- Add `Attrs::merge()` helper to combine two Attrs
- Add `Attrs` and `ElementBuilder` hx_* methods for fluent API

## Fixes
#4

## Changes

### src/hda/hda.mbt
- Add `HdaAttrs::_add()` internal helper for attribute accumulation
- Fix all HdaAttrs methods (get, post, swap, target, trigger, etc.) to use `_add()`
- Add `HdaAttrs::to_html_attrs()` to convert to `html.Attrs`

### src/html/html.mbt
- Add `Attrs::merge(prefer, fallback)` to combine two Attrs (prefer wins on conflicts)
- Add `Attrs` hx_* methods: `hx_get`, `hx_post`, `hx_put`, `hx_delete`, `hx_patch`, `hx_swap`, `hx_target`, `hx_trigger`
- Add `ElementBuilder` hx_* methods for fluent chaining

## Usage Example

**Before (manual string insertion):**
\`\`\`moonbit
let button = "<button hx-post=\"/counter/inc\" hx-target=\"#counter\" hx-swap=\"innerHTML\">+</button>"
\`\`\`

**After (type-safe):**
\`\`\`moonbit
let button = @html.button()
  .hx_post("/counter/inc")
  .hx_target("#counter")
  .hx_swap("innerHTML")
  .text("+")
\`\`\`

**Or using HdaAttrs:**
\`\`\`moonbit
let hda = @hda.HdaAttrs::new()
  .post("/counter/inc")
  .target("#counter")
  .swap(@hda.Swap::InnerHTML)

let button = @html.button()
  .attrs(hda.to_html_attrs())
  .text("+")
\`\`\`

## Test plan
- [x] Build passes: \`moon test\`
- [ ] Manual verification with counter example