### PR TITLE
docs: add client dependency policy (issue #7)

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -1,0 +1,45 @@
+# Engenis
+
+Pure MoonBit Hypermedia Driven Application (HDA) framework
+
+## Philosophy
+
+### Pure MoonBit
+
+可能な限り純粋なMoonBitコードで実装されています。外部の巨大なライブラリへの依存を避け、コンパイル時の型チェックを最大限に活用します。
+
+### 依存最小化 (Minimize Dependencies)
+
+クライアント側の依存関係を最小限に抑えることを目指しています。現在、counter exampleではHTMXをCDNから読み込んでいますが、これは開発中の一時的な措置です。詳細は [spec/CLIENT_DEPENDENCY.md](spec/CLIENT_DEPENDENCY.md) を参照してください。
+
+### Full HTML Swap but Type Safe
+
+HTML DSLを通じて型安全なハイパーメディアアプリケーションを構築できます。HTMXのような属性ベースの相互作用を、MoonBitの型システムの安全性と組み合わせて実現します。
+
+## Features
+
+* **型安全なHTML DSL** - 文字列結合ではなく、型付きビルダーでHTMLを構築
+* **HDA属性** - `hx_get`, `hx_post`, `hx_swap_safe` などの型安全な属性
+* **HTTPサーバー** - Pure MoonBit + `moonbitlang/async` による実装
+
+## Current Status
+
+* [x] Type-safe HTML DSL
+* [x] Type-safe HDA attributes
+* [x] HTTP server (Pure MoonBit + moonbitlang/async)
+* [ ] Pure MoonBit client runtime (planned)
+
+## Quick Start
+
+```bash
+# Counter exampleを実行
+./examples/counter/cmd/main/main
+```
+
+ブラウザで `http://127.0.0.1:8080` にアクセスしてください。
+
+## Documentation
+
+* [spec/AGENTS.md](spec/AGENTS.md) - 開発方針
+* [spec/CLIENT_DEPENDENCY.md](spec/CLIENT_DEPENDENCY.md) - クライアント依存ポリシー
+* [spec/DEEPRESEARCH.md](spec/DEEPRESEARCH.md) - HDAに関する研究ドキュメント

--- a/spec/AGENTS.md
+++ b/spec/AGENTS.md
@@ -8,3 +8,17 @@
   * 必要かつ下記にないものは自前
   * 例外: moonbitlang and mizchi
 3. Full HTML Swap but type safe
+
+## 依存最小化の方針
+
+クライアント側の依存関係を最小限に抑えることを目指します。
+
+### 現状
+
+* counter exampleではHTMXをCDNから使用
+* これは一時的な依存関係（詳細: [CLIENT_DEPENDENCY.md](CLIENT_DEPENDENCY.md)）
+
+### 将来
+
+* Pure MoonBitクライアントランタイムの実装
+* HTMX属性はすでに型安全に実装済みのため、移行は容易

--- a/spec/CLIENT_DEPENDENCY.md
+++ b/spec/CLIENT_DEPENDENCY.md
@@ -1,0 +1,71 @@
+# Client Dependency Policy
+
+## Current State
+
+### HTMX Usage
+
+counter example (`examples/counter`) では、HTMXをCDNから読み込んで使用しています。
+
+```moonbit
+@html.script()
+  .attr("src", @html.AttrValue::Str("https://unpkg.com/htmx.org@1.9.10"))
+  .empty(),
+```
+
+これは開発中の一時的な措置であり、将来的にはPure MoonBitのクライアントランタイムに置き換える予定です。
+
+## Policy: 依存最小化
+
+### Why Minimize Client Dependencies?
+
+1. **型安全性** - 外部のJavaScriptライブラリは文字列ベースの属性を使用するため、コンパイル時のチェックができません
+2. **デプロイの簡素化** - 外部CDNへの依存は、オフライン環境やプライベートネットワークで問題になります
+3. **バイナリサイズ** - 将来的には単一バイナリで完結させたい
+
+### What We Already Have
+
+* **サーバーサイド** - Pure MoonBit + `moonbitlang/async` のみで動作
+* **HTML DSL** - 型安全なHTMLビルダー（`src/html/html.mbt`）
+* **HDA属性** - 型安全なHTMX互換属性（`src/hda/hda.mbt`）
+
+これらはすでに型安全性を提供しており、クライアントランタイムへの移行が容易な設計になっています。
+
+## Future Work: Pure MoonBit Client Runtime
+
+### Design Goals
+
+* HTMXと同じ属性形式（`hx-get`, `hx-post` など）をサポート
+* MoonBitのJS/Wasmターゲットで動作
+* サーバーサイドのHTML DSLと完全な互換性
+
+### Planned Features
+
+* **属性パース** - `hx-*` 属性の読み取りと解釈
+* **イベントハンドリング** - click, change などのイベント検知
+* **HTTP通信** - fetch APIによるサーバーとの通信
+* **DOM操作** - Swap戦略（`innerHTML`, `outerHTML` など）の実装
+* **ターゲット選択** - CSSセレクタによる要素の特定
+
+### Migration Path
+
+1. HTMX属性はすでに型安全に実装されている（変更不要）
+2. 将来的には同じ属性をPure MoonBitランタイムで処理
+3. API互換性を維持したまま移行可能
+
+## Implementation Notes
+
+### Current Limitations
+
+* MoonBitのJS/WasmターゲットでのDOM操作はまだ実験的
+* ブラウザAPIとの相互運用性に関するドキュメントが不足
+
+### Next Steps
+
+1. MoonBitのJS/WasmターゲットでのDOM操作の調査
+2. `src/client/runtime.mbt` の設計と実装
+3. counter example のPure MoonBit化
+
+## References
+
+* [spec/DEEPRESEARCH.md](DEEPRESEARCH.md) - HDAおよび "Beyond HTMX" に関する研究
+* [spec/AGENTS.md](AGENTS.md) - 開発方針

--- a/src/http/counter.mbt
+++ b/src/http/counter.mbt
@@ -46,6 +46,9 @@ fn render_home_page() -> String {
               .empty(),
             @html.title()
               .text("Engenis Counter"),
+            // TEMPORARY: HTMX is used as a client-side dependency during development.
+            // This will be replaced with a Pure MoonBit client runtime in the future.
+            // See: spec/CLIENT_DEPENDENCY.md
             @html.script()
               .attr("src", @html.AttrValue::Str("https://unpkg.com/htmx.org@1.9.10"))
               .empty(),


### PR DESCRIPTION
## Summary

- **README.mbt.md**: プロジェクトの概要とPure MoonBit哲学、依存最小化の方針を記載
- **spec/CLIENT_DEPENDENCY.md**: クライアント依存の現状とポリシー、Pure MoonBitランタイムへのロードマップを記載
- **spec/AGENTS.md**: 依存最小化の方針を追加
- **src/http/counter.mbt**: HTMX依存が一時的であることをコメントで明示

## Test plan

- [x] `moon test` - 46 tests passed
- [x] `moon build` - Build successful
- [x] Documentation is consistent with issue #7 requirements

Closes #7