### PR TITLE
Client runtime: triggers + swap strategies

### DIFF
--- a/src/client/attr.mbt
+++ b/src/client/attr.mbt
@@ -17,3 +17,8 @@ pub fn hx_target(el : Element) -> String? {
 pub fn hx_swap(el : Element) -> String? {
   get_attr_value(el, "hx-swap")
 }
+
+///|
+pub fn hx_trigger(el : Element) -> String? {
+  get_attr_value(el, "hx-trigger")
+}

--- a/src/client/dom.mbt
+++ b/src/client/dom.mbt
@@ -38,6 +38,18 @@ extern "js" fn set_outer_html(el : Element, html : String) -> Unit =
   #| (el, html) => { el.outerHTML = html; }
 
 ///|
+extern "js" fn insert_adjacent_html(
+  el : Element,
+  position : String,
+  html : String,
+) -> Unit =
+  #| (el, position, html) => { el.insertAdjacentHTML(position, html); }
+
+///|
+extern "js" fn remove_element(el : Element) -> Unit =
+  #| (el) => { el.remove(); }
+
+///|
 extern "js" fn add_event_listener(
   el : Element,
   name : String,

--- a/src/client/runtime.mbt
+++ b/src/client/runtime.mbt
@@ -7,24 +7,37 @@ fn resolve_target(doc : Document, el : Element, selector : String?) -> Element? 
 }
 
 ///|
+fn run_fetch(
+  doc : Document,
+  el : Element,
+  target_sel : String?,
+  swap : @html.Swap,
+  url : String,
+) -> Unit {
+  match resolve_target(doc, el, target_sel) {
+    Some(target) =>
+      fetch_text(url, fn(body) { apply_swap(swap, target, body) }, fn(msg) {
+        println("fetch failed: " + msg)
+      })
+    None => ()
+  }
+}
+
+///|
 fn bind_hx_get(doc : Document, el : Element) -> Unit {
   match hx_get(el) {
     None => ()
     Some(url) => {
       let target_sel = hx_target(el)
       let swap = parse_swap(hx_swap(el))
-      add_event_listener(el, "click", fn(ev) {
-        prevent_default(ev)
-        match resolve_target(doc, el, target_sel) {
-          Some(target) =>
-            fetch_text(url, fn(body) { apply_swap(swap, target, body) }, fn(
-              msg,
-            ) {
-              println("fetch failed: " + msg)
-            })
-          None => ()
-        }
-      })
+      match parse_trigger(hx_trigger(el)) {
+        Immediate => run_fetch(doc, el, target_sel, swap, url)
+        Event(event) =>
+          add_event_listener(el, event, fn(ev) {
+            prevent_default(ev)
+            run_fetch(doc, el, target_sel, swap, url)
+          })
+      }
     }
   }
 }

--- a/src/client/swap.mbt
+++ b/src/client/swap.mbt
@@ -30,7 +30,11 @@ pub fn apply_swap(swap : @html.Swap, target : Element, html : String) -> Unit {
   match swap {
     @html.Swap::OuterHTML => set_outer_html(target, html)
     @html.Swap::InnerHTML => set_inner_html(target, html)
-    // TODO: implement other swap strategies in the runtime.
-    _ => set_inner_html(target, html)
+    @html.Swap::BeforeBegin => insert_adjacent_html(target, "beforebegin", html)
+    @html.Swap::AfterBegin => insert_adjacent_html(target, "afterbegin", html)
+    @html.Swap::BeforeEnd => insert_adjacent_html(target, "beforeend", html)
+    @html.Swap::AfterEnd => insert_adjacent_html(target, "afterend", html)
+    @html.Swap::Delete => remove_element(target)
+    @html.Swap::None => ()
   }
 }

--- a/src/client/trigger.mbt
+++ b/src/client/trigger.mbt
@@ -1,0 +1,45 @@
+///|
+pub(all) enum TriggerMode {
+  Event(String)
+  Immediate
+} derive(Show, Eq)
+
+///|
+fn first_segment(value : String, sep : String) -> String {
+  let parts = value.split(sep).to_array()
+  if parts.length() == 0 {
+    ""
+  } else {
+    parts[0].to_string()
+  }
+}
+
+///|
+fn normalize_event(value : String) -> String? {
+  let trimmed = value.trim().to_string()
+  if trimmed.length() == 0 {
+    return None
+  }
+  let comma = first_segment(trimmed, ",")
+  let bracket = first_segment(comma, "[")
+  let space = first_segment(bracket, " ")
+  let event = space.trim().to_string()
+  if event.length() == 0 {
+    None
+  } else {
+    Some(event)
+  }
+}
+
+///|
+pub fn parse_trigger(value : String?) -> TriggerMode {
+  match value {
+    Some(raw) =>
+      match normalize_event(raw) {
+        Some("load") => Immediate
+        Some(event) => Event(event)
+        None => Event("click")
+      }
+    None => Event("click")
+  }
+}


### PR DESCRIPTION
Summary:
- parse hx-trigger (supports load + first event)
- implement swap strategies via insertAdjacentHTML/remove
- reuse fetch path through shared helper

Testing:
- moon check --target js examples/client_poc/cmd/main

Closes #28