### PR TITLE
Typed routing: implementation plan

### DIFF
--- a/spec/ROUTING_RFC.md
+++ b/spec/ROUTING_RFC.md
@@ -112,3 +112,30 @@ let link = @hda.LinkRel::new(
 - Decide path template syntax (e.g., `:id` vs `{id}`).
 - Add round-trip tests for encode/decode.
 - Decide if query params should support multi-values.
+
+## Implementation Plan (Concrete Tasks)
+
+1) Core types
+- Add `RouteError` enum to `src/router/route.mbt` or `src/router/error.mbt`.
+- Define `QueryParams` in `src/router/query.mbt`.
+- Extend `PathParams` with typed getters (`get_int`, `get_bool`).
+
+2) Path template parsing
+- Add `PathTemplate` representation in `src/router/template.mbt`.
+- Implement parser for `:param` tokens and static segments.
+- Provide `match_path(template, path) -> Result[PathParams, RouteError]`.
+
+3) RouteSpec API
+- Add `RouteSpec[T]` and constructors in `src/router/spec.mbt`.
+- Implement `RouteSpec::match` that checks method + path + query.
+- Implement `RouteSpec::encode` using typed params.
+
+4) HTTP integration
+- Expose raw query string in `src/http/types.mbt` (or update parsing).
+- Ensure `Request` provides method + path + query for matching.
+
+5) Tests
+- `src/router/route_spec_test.mbt`: happy path + method mismatch.
+- `src/router/template_test.mbt`: template parsing + invalid paths.
+- `src/router/query_test.mbt`: query parsing + missing/invalid params.
+- Optional: property tests for encode/decode round-trip.


### PR DESCRIPTION
Summary:
- add concrete implementation plan to routing RFC

Testing:
- not run (docs only)

Closes #29